### PR TITLE
use wikipedia api rest v1 for search

### DIFF
--- a/src/store/search.js
+++ b/src/store/search.js
@@ -12,7 +12,7 @@ export default {
   actions: {
     search: ({ commit }, query) => {
       const queryString = query.trim();
-      const url = "https://en.wikipedia.org/w/api.php?action=query&generator=prefixsearch&prop=description|pageimages|pageprops&piprop=thumbnail&ppprop=displaytitle&redirects=false&pithumbsize=64&gpslimit=10&gpsnamespace=0&format=json&formatversion=2&origin=*&gpssearch=" + queryString;
+      const url = `https://en.wikipedia.org/w/rest.php/v1/search/title?q=${queryString}&limit=10`;
 
       commit('setQuery', query)
       
@@ -23,13 +23,12 @@ export default {
       }
 
       request( url, data => {
-        if ( data.query && data.query.pages ) {
-          data.query.pages.sort( ( a, b ) => a.index - b.index );    
-          commit('setSearchResults', Object.values(data.query.pages).map(p => {
+        if ( data.pages ) {
+          commit('setSearchResults', Object.values(data.pages).map(p => {
             return {
               title: p.title,
               desc: p.description,
-              thumb: p.thumbnail && p.thumbnail.source,
+              thumb: p.thumbnail && p.thumbnail.url,
               goto: { name: 'BrowseArticle', params: { article: p.title } }
             }
           }))


### PR DESCRIPTION
I just discovered this endpoint, and it gave a better result (means we get the same result as wikipedia site)

| Before \| After |
| --- |
| ![image](https://user-images.githubusercontent.com/2560096/135247061-fd7f06c3-4223-4b2d-a6ec-73762c3fbfc8.png) |

Test it here https://wikimedia.github.io/wikistories-prototype/new-api/#/searchwikipedia