### PR TITLE
Scope Back styling to avoid collision

### DIFF
--- a/src/components/Back.vue
+++ b/src/components/Back.vue
@@ -6,7 +6,7 @@
     name: 'Back'
   }
 </script>
-<style>
+<style scoped>
     .back {
         background-image: url(../images/back.svg);
         background-repeat: no-repeat;


### PR DESCRIPTION
why? because of here
![image](https://user-images.githubusercontent.com/2560096/135853326-c6c11aa2-4cf6-46c3-af4f-417b080cdcdd.png)
