### PR TITLE
Add next buttons

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -2,7 +2,7 @@
     <div class="navigator">
         <!-- Use <router-link> but able to call event before route? -->
         <div v-if="onBack" class="back" @click="onBack"/>
-        <div v-if="onNext" class="next" @click="onNext"/>
+        <div v-if="onNext" class="next" @click="onNext">{{ $i18n('btn-next') }}</div>
         <span class="info" v-if="info">{{ info }}</span>
     </div>
 </template>
@@ -40,13 +40,12 @@
       cursor: pointer;
     }
     .navigator .next {
-      background-image: url(../images/back.svg);
       position: absolute;
-      transform: scaleX(-1); 
       width: 16px;
       height: 16px;
       right: 0;
-      margin: 20px 0;
+      margin: 20px;
       cursor: pointer;
+      font-weight: bold;
     }
 </style>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -7,7 +7,6 @@ export default {
   'search-media-info': '$1 selected',
   'wikimedia-commons': 'Commons',
   'wikipedia': 'Wikipedia',
-  'btn-publish': 'Publish',
   'btn-publish-wikistory': 'Publish Wikistory',
   'btn-highlight': 'Highlight',
   'btn-clear': 'Clear',

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -7,7 +7,6 @@ export default {
   'search-media-info': '$1 {{PLURAL:$1|selectionné|selectionnés}}',
   'wikimedia-commons': 'Commons',
   'wikipedia': 'Wikipédia',
-  'btn-publish': 'Publier',
   'btn-publish-wikistory': 'Publier la Wikistoire',
   'btn-highlight': 'Surligner',
   'btn-clear': 'Annuler',

--- a/src/i18n/id.js
+++ b/src/i18n/id.js
@@ -7,7 +7,6 @@ export default {
   'search-media-info': '$1 dipilih',
   'wikimedia-commons': 'Commons',
   'wikipedia': 'Wikipedia',
-  'btn-publish': 'Terbitkan',
   'btn-publish-wikistory': 'Publikasikan Wikistory',
   'btn-highlight': 'Sorot teks',
   'btn-clear': 'Hapus pilihan',

--- a/src/i18n/zh.js
+++ b/src/i18n/zh.js
@@ -7,7 +7,6 @@ export default {
   'search-media-info': '$1 選擇',
   'wikimedia-commons': '維基共享資源',
   'wikipedia': '維基百科',
-  'btn-publish': '發佈',
   'btn-publish-wikistory': '發佈 Wikistory',
   'btn-highlight': 'Highlight',
   'btn-clear': '移除',

--- a/src/views/Story.vue
+++ b/src/views/Story.vue
@@ -2,7 +2,7 @@
 <div class="view story">
     <PrimaryButton class="publish-button"
         v-if="canPublish"
-        :text="$i18n('btn-publish')"
+        :text="$i18n('btn-next')"
         :onClick="onPublish"
     />
     <CurrentFrame />


### PR DESCRIPTION
https://phabricator.wikimedia.org/T295049

Replace the forward arrow button by "Next" in Navigator.
Replace the "publish" button on the last frame by "Next".

https://wikimedia.github.io/wikistories-prototype/T295049/#/