### PR TITLE
Set min width height for next btn

### DIFF
--- a/src/components/Navigator.vue
+++ b/src/components/Navigator.vue
@@ -41,8 +41,8 @@
     }
     .navigator .next {
       position: absolute;
-      width: 16px;
-      height: 16px;
+      min-width: 16px;
+      min-height: 16px;
       right: 0;
       margin: 20px;
       cursor: pointer;


### PR DESCRIPTION
Demo Link: https://wikimedia.github.io/wikistories-prototype/ui-next-btn/#/

| Before | After | Do not affect the enough space lang |
| --- | --- | --- |
| <img width="375" alt="image" src="https://user-images.githubusercontent.com/2560096/143326630-48565f08-ea27-4d53-97d9-549c782baa58.png"> | <img width="375" alt="image" src="https://user-images.githubusercontent.com/2560096/143326583-1722fdd1-0e54-41e4-9bbb-1b3e7113ed0d.png"> | <img width="639" alt="image" src="https://user-images.githubusercontent.com/2560096/143326721-24d02ca2-51b6-4cb9-b99b-b20cce9877f5.png"> |
