### PR TITLE
T296727: new search images flow

### DIFF
--- a/src/components/Frames.vue
+++ b/src/components/Frames.vue
@@ -7,7 +7,7 @@
                 :class="{'selected-frame': frame.selected}"
                 :style="frame.style"
                 @click="selectFrame(frame.id)" />
-        <div class="frame btn-add-frame" @click="addFrame">+</div>
+        <router-link to="/searchcommons" class="frame btn-add-frame">+</router-link>
     </div>
 </template>
 <script>
@@ -47,6 +47,8 @@
         vertical-align: middle;
         margin-left: auto;
         margin-right: 15px;
+        text-decoration: none;
+        color: black;
     }
     .selected-frame {
         outline: #3366CC auto 4px;

--- a/src/components/SearchToolbar.vue
+++ b/src/components/SearchToolbar.vue
@@ -1,7 +1,5 @@
 <template>
     <div class="search-toolbar">
-        <router-link to="/searchcommons" class="commons logo">{{ $i18n('wikimedia-commons') }}</router-link>
-        <div class="border" />
         <router-link to="/searchwikipedia" class="wikipedia logo">{{ $i18n('wikipedia') }}</router-link>
     </div>
 </template>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -3,7 +3,7 @@ export default {
   'btn-create': 'Create a story',
   'btn-restart-story': 'Start again',
   'search-box': 'Search Wikipedia',
-  'search-media': 'Search Media',
+  'search-media': 'Search images',
   'search-media-info': '$1 selected',
   'wikimedia-commons': 'Commons',
   'wikipedia': 'Wikipedia',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -3,7 +3,7 @@ export default {
   'btn-create': 'Crea una historia',
   'btn-restart-story': 'Empezar de nuevo',
   'search-box': 'Buscar en Wikipedia',
-  'search-media': 'Buscar en Commons',
+  'search-media': 'Buscar imagenes',
   'search-media-info': '$1 seleccionado',
   'wikimedia-commons': 'Commons',
   'wikipedia': 'Wikipedia',

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -3,7 +3,7 @@ export default {
   'btn-create': 'Creer une histoire',
   'btn-restart-story': 'Recommencer',
   'search-box': 'Recherche dans Wikipédia',
-  'search-media': 'Recherche de Média',
+  'search-media': 'Recherche des images',
   'search-media-info': '$1 {{PLURAL:$1|selectionné|selectionnés}}',
   'wikimedia-commons': 'Commons',
   'wikipedia': 'Wikipédia',

--- a/src/i18n/id.js
+++ b/src/i18n/id.js
@@ -3,7 +3,7 @@ export default {
   'btn-create': 'Buat cerita',
   'btn-restart-story': 'mulai dari awal',
   'search-box': 'Cari di wikipedia',
-  'search-media': 'Cari media',
+  'search-media': 'Cari gambar',
   'search-media-info': '$1 dipilih',
   'wikimedia-commons': 'Commons',
   'wikipedia': 'Wikipedia',

--- a/src/i18n/pt.js
+++ b/src/i18n/pt.js
@@ -3,7 +3,7 @@ export default {
   'btn-create': 'Crie uma historia',
   'btn-restart-story': 'Começar de novo',
   'search-box': 'Pesquisar Wikipedia',
-  'search-media': 'Pesquisar Commons',
+  'search-media': 'Pesquisar imagens',
   'search-media-info': '$1 selecionado',
   'wikimedia-commons': 'Commons',
   'wikipedia': 'Wikipedia',

--- a/src/i18n/zh.js
+++ b/src/i18n/zh.js
@@ -3,7 +3,7 @@ export default {
   'btn-create': '創建故事',
   'btn-restart-story': '重新開始',
   'search-box': '搜尋維基百科',
-  'search-media': '搜索图片',
+  'search-media': '搜尋圖片',
   'search-media-info': '$1 選擇',
   'wikimedia-commons': '維基共享資源',
   'wikipedia': '維基百科',

--- a/src/i18n/zh.js
+++ b/src/i18n/zh.js
@@ -3,7 +3,7 @@ export default {
   'btn-create': '創建故事',
   'btn-restart-story': '重新開始',
   'search-box': '搜尋維基百科',
-  'search-media': '搜尋媒體',
+  'search-media': '搜索图片',
   'search-media-info': '$1 選擇',
   'wikimedia-commons': '維基共享資源',
   'wikipedia': '維基百科',

--- a/src/store/searchCommons.js
+++ b/src/store/searchCommons.js
@@ -22,7 +22,8 @@ export default {
   actions: {
     search: ({ commit }, query) => {
       const queryString = query.trim();
-      const url = `https://commons.wikimedia.org/w/api.php?action=query&format=json&origin=*&uselang=${lang}&generator=search&gsrsearch=filetype%3Abitmap%7Cdrawing%20${queryString}&gsrlimit=40&gsroffset=0&gsrinfo=totalhits%7Csuggestion&gsrprop=snippet&prop=imageinfo&gsrnamespace=6&iiprop=url%7Cextmetadata&iiurlheight=180&iiextmetadatafilter=License%7CLicenseShortName%7CImageDescription%7CArtist&iiextmetadatalanguage=${lang}`
+      const commonsLimit = 40
+      const url = `https://commons.wikimedia.org/w/api.php?action=query&format=json&origin=*&uselang=${lang}&generator=search&gsrsearch=filetype%3Abitmap%7Cdrawing%20${queryString}&gsrlimit=${commonsLimit}&gsroffset=0&gsrinfo=totalhits%7Csuggestion&gsrprop=snippet&prop=imageinfo&gsrnamespace=6&iiprop=url%7Cextmetadata&iiurlheight=180&iiextmetadatafilter=License%7CLicenseShortName%7CImageDescription%7CArtist&iiextmetadatalanguage=${lang}`
       const wikipediaUrl = `https://${lang}.wikipedia.org/api/rest_v1/page/media-list/${encodeURIComponent( queryString )}`
 
       commit('setQuery', query)
@@ -73,7 +74,7 @@ export default {
       const wikipediaCallback = (data) => {
         const wikipediaResults = data.items.reduce((mediaArray, item, i)=>{
           if ( item.showInGallery && item.type === 'image' ) {
-            const withBuffer = i + 100
+            const withBuffer = i + commonsLimit;
             return mediaArray.concat({
               id: withBuffer.toString(),
               title: item.title,
@@ -84,10 +85,10 @@ export default {
           return mediaArray
         },[])
         
-        commit('setResults', wikipediaResults)
+        commit('setResults', wikipediaResults);
       }
-
-      parallelRequests([url, wikipediaUrl], [commonsCallback, wikipediaCallback])      
+      
+      parallelRequests([url, wikipediaUrl], [commonsCallback, wikipediaCallback]);
     },
     clear: ({commit}) => {
       abortAllRequest();

--- a/src/store/story.js
+++ b/src/store/story.js
@@ -140,7 +140,7 @@ export default {
       }
     },
     valid: (state) => {
-      return state.frames.length >= 2 && state.frames.every( f => f.img && f.text )
+      return state.frames.length >= 2 && state.frames.every( f => f.img )
     },
     attributionData: (state) => {
       return state.frames.map(f => {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -23,16 +23,15 @@ export const request = ( url, callback ) => {
 
 export const parallelRequests = (urls, callbacks) => {
 	abortAllRequest();
-	
 	for (let i = 0; i < urls.length; i++) {
-    let xhr = new XMLHttpRequest();
-    xhr.open("GET", urls[i]);
+		let xhr = new XMLHttpRequest();
+		xhr.open("GET", urls[i]);
 		xhr.addEventListener('readystatechange', () => {
-        if(xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
-            const data = JSON.parse(xhr.responseText);
-						callbacks[i](data)
-        }
-    });
+			if(xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
+				const data = JSON.parse(xhr.responseText);
+				callbacks[i](data)
+			}
+		});
 		xhr.send();
 		abortFunctions.push( xhr );
 	}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -20,3 +20,20 @@ export const request = ( url, callback ) => {
 
 	abortFunctions.push( xhr );
 };
+
+export const parallelRequests = (urls, callbacks) => {
+	abortAllRequest();
+	
+	for (let i = 0; i < urls.length; i++) {
+    let xhr = new XMLHttpRequest();
+    xhr.open("GET", urls[i]);
+		xhr.addEventListener('readystatechange', () => {
+        if(xhr.readyState === XMLHttpRequest.DONE && xhr.status === 200) {
+            const data = JSON.parse(xhr.responseText);
+						callbacks[i](data)
+        }
+    });
+    xhr.send();
+		abortFunctions.push( xhr );
+	}
+}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -33,7 +33,7 @@ export const parallelRequests = (urls, callbacks) => {
 						callbacks[i](data)
         }
     });
-    xhr.send();
+		xhr.send();
 		abortFunctions.push( xhr );
 	}
-}
+};

--- a/src/views/Story.vue
+++ b/src/views/Story.vue
@@ -39,11 +39,12 @@ export default {
     }
   },
   mounted: function() {
-    const attributionNeeded = this.attributionData.find(e => e.title !== '' && !e.attribution)
-
-    if ( attributionNeeded ) {
-      this.fetchImgAttribution({ id: attributionNeeded.id, title: attributionNeeded.title } )
-    }
+    this.attributionData.forEach(frame => {
+      const attributionNeeded = frame.title !== '' && !frame.attribution
+      if ( attributionNeeded ) {
+        this.fetchImgAttribution({ id: frame.id, title: frame.title } )
+      }
+    })
   }
 }
 </script>


### PR DESCRIPTION
Phabricator: https://phabricator.wikimedia.org/T296727
Demo: https://wikimedia.github.io/wikistories-prototype/T296727-image-search/#/

### Objective

Per the phabricator, the new search images flow explores mixing both the Commons and Wikipedia article images (if it exists) for the same string target. This is done with an api method for parallel requests invoked as the user searches for images. 